### PR TITLE
Add terraform directory with Terraform Refactor and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,32 @@ __pycache__
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# Terraform
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.14.0"
+  constraints = "5.14.0"
+  hashes = [
+    "h1:KjsjWBIOb+WQRSEaQex2KGwlmCG+SrAUcLKXoH0actE=",
+    "zh:03b80869b97dfca4ce6ee94a005e15ccec4d98af0876084a963963b05c9ab743",
+    "zh:11d148800fe028fcd10590f0473c5df306e220776e359aa838c2f07e5a89187e",
+    "zh:15d696cf583dc2917b257891e4a33afe7c3e8f20b63183f510267d709baaaf3d",
+    "zh:34c41e44534fbbf95a5f89b38404ee52b41c6c70af68f7e63a423b276fbcf797",
+    "zh:4211d0fd4753f7ba202f3e4a8afb2e03d12112dd4db4f9267c472bd597dc71ca",
+    "zh:47b6017d0cdd2f62b9e46137de38cd618441f658f8570a8e2687cce7643bf953",
+    "zh:51785b942d6f588825f4bfa86e05502be8721194b289c474121072e49acff6c3",
+    "zh:565f76885d41ecfea192b8a2e2f3d4b3dd278790d1d82b204706ae3582d51cf6",
+    "zh:703d670e1d73360d2533b02dbe9e2e055bf6f36a478cd4d66f2349861575c2ed",
+    "zh:7e4701f38590c22066da90b75dd92d81a685225d2d222d22425b7ccb26e92b4a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ca3449252d70df14ad713d5b95fa0610da8087f12c9deb87beffe788f518d06d",
+    "zh:e2ed3d6d8c12d3fe56fb03fe272779270a92f6157ade8c3db1c987b83b62e68c",
+    "zh:f0b07b84a43d1afc3a9790ca699771970525c132fa8551e7b326d1f263414dd1",
+    "zh:f1d83b3e5a29bae471f9841a4e0153eac5bccedbdece369e2f6186e9044db64e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terraform/config.auto.tfvars
+++ b/terraform/config.auto.tfvars
@@ -1,0 +1,42 @@
+// This file contains the configuration for the SDC AWS Pipeline
+
+# AWS Deployment Region
+# Region that the pipeline will be deployed to
+deployment_region = "us-east-1"
+
+# Mission Name
+# This is the name of the mission that will be used to dynamically create the instrument buckets
+mission_name = "hermes"
+
+# Instrument Names Used in the Mission. 
+# The names are used to dynamically create the instrument bucket
+instrument_names = ["eea", "nemisis", "merit", "spani"]
+
+# Valid Data Levels
+# This is a list of the valid data levels for the mission
+valid_data_levels = ["l0", "l1", "ql"]
+
+# Timestream Database and Table Names for Logs
+# The names of the timestream database and table that will be created to store logs
+timestream_database_name      = "sdc_aws_logs"
+timestream_s3_logs_table_name = "sdc_aws_s3_bucket_log_table"
+
+# S3 Instrument Bucket Name
+# The names of the buckets that will be created for the mission
+incoming_bucket_name = "swsoc-incoming"
+
+# S3 Sorting Lambda Bucket Name
+# The name of the bucket that will be created to store the build artifacts for the sorting lambda
+sorting_lambda_bucket_name = "swsoc-sorting-lambda"
+
+# S3 Server Access Logs Bucket
+# The name of the bucket that will be created to store the s3 server access logs
+s3_server_access_logs_bucket_name = "swsoc-s3-server-access-logs"
+
+# Processing Lambda ECR Repository Name
+# The name of the ECR repository that will be created to store the processing lambda image
+processing_function_private_ecr_name = "sdc_aws_processing_lambda"
+
+# Docker Base ECR Repository Name
+# The name of the ECR repository that will be created to store the docker base image
+docker_base_public_ecr_name = "swsoc-docker-lambda-base"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,60 @@
+// Main Terraform configuration for the SDC Pipeline
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.14.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "smce-swsoc-terraform"
+    key     = "smce-swsoc.terraform.tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+
+
+}
+
+provider "aws" {
+  region = var.deployment_region
+}
+
+// Identify the current AWS account
+data "aws_caller_identity" "current" {}
+
+// Locals for SDC Pipeline
+locals {
+  is_production = terraform.workspace == "prod"
+
+  environment_short_name = {
+    default = "dev-"
+    dev     = "dev-"
+    prod    = ""
+  }[terraform.workspace]
+
+  environment_full_name = {
+    default = "Development"
+    dev     = "Development"
+    prod    = "Production"
+  }[terraform.workspace]
+
+  standard_tags = {
+    "Environment" = local.environment_full_name
+    "Purpose"     = "SWSOC Pipeline"
+  }
+
+  data_levels     = slice(var.valid_data_levels, 0, length(var.valid_data_levels) - 1)
+  last_data_level = element(var.valid_data_levels, length(var.valid_data_levels) - 1)
+
+  instrument_bucket_names = [for bucket in var.instrument_names : "${var.mission_name}-${bucket}"]
+  bucket_list             = concat([var.incoming_bucket_name], [var.sorting_lambda_bucket_name], local.instrument_bucket_names)
+}
+
+

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,1 @@
+// Outputs we want to export to other terraform projects

--- a/terraform/sdc_aws_pipeline_infrastructure.tf
+++ b/terraform/sdc_aws_pipeline_infrastructure.tf
@@ -1,0 +1,328 @@
+// Resource for Infrastructure for the SDC Pipeline
+
+
+///////////////////////////////////////
+// Timestream Database for storing logs
+///////////////////////////////////////
+
+// Timestream Database for storing logs
+resource "aws_timestreamwrite_database" "sdc_aws_timestream_db" {
+  database_name = "${local.environment_short_name}${var.timestream_database_name}"
+  tags          = local.standard_tags
+}
+
+// Timestream Table for storing logs
+resource "aws_timestreamwrite_table" "sdc_aws_timestream_table" {
+  table_name    = "${local.environment_short_name}${var.timestream_s3_logs_table_name}"
+  database_name = aws_timestreamwrite_database.sdc_aws_timestream_db.database_name
+
+  retention_properties {
+    memory_store_retention_period_in_hours  = 24
+    magnetic_store_retention_period_in_days = 30
+  }
+
+  depends_on = [aws_timestreamwrite_database.sdc_aws_timestream_db]
+  tags       = local.standard_tags
+}
+
+
+///////////////////////////////////////
+// S3 Buckets for SDC Pipeline
+///////////////////////////////////////
+
+// Creates the access policy for the access logs bucket if this is the production environment
+resource "aws_s3_bucket" "access_logs" {
+  count  = local.is_production ? 1 : 0
+  bucket = var.s3_server_access_logs_bucket_name
+
+  versioning {
+    enabled = true
+  }
+
+  tags = local.standard_tags
+}
+
+// Creates the access policy for the access logs bucket if this is the production environment
+resource "aws_s3_bucket_policy" "access_logs_access_policy" {
+  count  = local.is_production ? 1 : 0
+  bucket = aws_s3_bucket.access_logs[0].bucket
+
+  policy = jsonencode({
+    Id      = "S3-Access-Logs-Policy"
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "s3:PutObject"
+        Effect = "Allow"
+        Principal = {
+          Service = "logging.s3.amazonaws.com"
+        }
+        Resource = "arn:aws:s3:::${aws_s3_bucket.access_logs[0].bucket}/*"
+        Sid      = "S3PolicyStmt-DO-NOT-MODIFY-1663700656545"
+      }
+    ]
+  })
+}
+
+// Creates all the buckets for the pipeline
+resource "aws_s3_bucket" "sdc_buckets" {
+  for_each = {
+    for bucket in local.bucket_list : bucket => bucket
+  }
+
+  bucket = "${local.environment_short_name}${each.value}"
+  versioning {
+    enabled = true
+  }
+
+  // Enable server access logging if this is the production environment
+  dynamic "logging" {
+    for_each = local.environment_short_name == "prod" ? [1] : []
+    content {
+      target_bucket = aws_s3_bucket.access_logs[0].id
+      target_prefix = "${each.value}/"
+    }
+  }
+
+  tags = local.standard_tags
+}
+
+
+////////////////////////////////////////////
+// SNS Topics for SDC Pipeline
+////////////////////////////////////////////
+
+// Creates topics for each instrument
+resource "aws_sns_topic" "sns_topics" {
+  for_each = toset(local.instrument_bucket_names)
+  name     = "${local.environment_short_name}${each.value}-sns-topic"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sns:Publish"
+        Effect = "Allow"
+        Principal = {
+          Service = "s3.amazonaws.com"
+        }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:s3:::${local.environment_short_name}${each.value}"
+          }
+        }
+        Resource = "arn:aws:sns:${var.deployment_region}:${data.aws_caller_identity.current.account_id}:${local.environment_short_name}${each.value}-sns-topic"
+        Sid      = "SNSPublishAccess-${local.environment_short_name}${each.value}"
+      }
+    ]
+  })
+  tags = local.standard_tags
+}
+
+
+////////////////////////////////////////////
+// SQS Queues for SDC Pipeline
+////////////////////////////////////////////
+
+// Creates queues for each instrument
+resource "aws_sqs_queue" "sqs_queue" {
+  for_each = toset(local.instrument_bucket_names)
+
+  name = "${local.environment_short_name}${each.value}-sqs-queue"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sqs:SendMessage",
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = "arn:aws:sns:${var.deployment_region}:${data.aws_caller_identity.current.account_id}:${local.environment_short_name}${each.value}-sns-topic"
+          }
+        },
+        Effect = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Resource = "arn:aws:sqs:${var.deployment_region}:${data.aws_caller_identity.current.account_id}:${local.environment_short_name}${each.value}-sqs-queue"
+      },
+      {
+        Action = ["sqs:ReceiveMessage", "sqs:SendMessage"],
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = "arn:aws:sns:${var.deployment_region}:${data.aws_caller_identity.current.account_id}:${local.environment_short_name}${each.value}-sns-topic"
+          }
+        },
+        Effect = "Allow",
+        Principal = {
+          AWS = "*"
+        },
+        Resource = "arn:aws:sqs:${var.deployment_region}:${data.aws_caller_identity.current.account_id}:${local.environment_short_name}${each.value}-sqs-queue"
+      },
+      {
+        Action = ["sqs:ReceiveMessage", "sqs:SendMessage"],
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = "arn:aws:s3:::${local.environment_short_name}${each.value}"
+          }
+        },
+        Effect = "Allow",
+        Principal = {
+          AWS = "*"
+        },
+        Resource = "arn:aws:sqs:${var.deployment_region}:${data.aws_caller_identity.current.account_id}:${local.environment_short_name}${each.value}-sqs-queue"
+      },
+      {
+        Action = ["sqs:GetQueueAttributes", "sqs:GetQueueUrl", "sqs:SendMessage"],
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:s3:::${local.environment_short_name}${each.value}"
+          }
+        },
+        Effect = "Allow",
+        Principal = {
+          Service = "s3.amazonaws.com"
+        },
+        Resource = "arn:aws:sqs:${var.deployment_region}:${data.aws_caller_identity.current.account_id}:${local.environment_short_name}${each.value}-sqs-queue"
+      }
+    ]
+  })
+  sqs_managed_sse_enabled = true
+  tags                    = local.standard_tags
+}
+
+
+///////////////////////////////////////
+// ECR Repositories for SDC Pipeline
+///////////////////////////////////////
+
+// Private ECR for the processing function
+resource "aws_ecr_repository" "processing_function_private_ecr" {
+  name                 = "${local.environment_short_name}${var.processing_function_private_ecr_name}"
+  image_tag_mutability = "MUTABLE"
+  tags                 = local.standard_tags
+}
+
+// Public ECR for the docker base image
+resource "aws_ecrpublic_repository" "docker_base_public_ecr" {
+  repository_name = "${local.environment_short_name}${var.docker_base_public_ecr_name}"
+  tags            = local.standard_tags
+}
+
+
+///////////////////////////////////////
+// IAM Policies for SDC Pipeline
+///////////////////////////////////////
+
+// Timestream Access Policy
+resource "aws_iam_policy" "timestream_policy" {
+  name        = "${local.environment_full_name}TimestreamAccessPolicy"
+  description = "Provides access to Timestream"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "timestream:WriteRecords",
+          "timestream:DescribeEndpoints",
+          "timestream:DescribeDatabase",
+          "timestream:DescribeTable"
+        ],
+        Effect   = "Allow",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+// Logs Access Policy
+resource "aws_iam_policy" "logs_access_policy" {
+  name        = "${local.environment_full_name}LogsAccessPolicy"
+  description = "Provides access to CloudWatch Logs"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Effect   = "Allow",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+
+// S3 Bucket Access Policy
+resource "aws_iam_policy" "s3_bucket_access_policy" {
+  name        = "${local.environment_full_name}S3BucketAccessPolicy"
+  description = "Provides access to specific S3 buckets"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "s3:Abort*",
+          "s3:DeleteObject*",
+          "s3:GetBucket*",
+          "s3:GetObject*",
+          "s3:List*",
+          "s3:PutObject",
+          "s3:PutObjectLegalHold",
+          "s3:PutObjectRetention",
+          "s3:PutObjectTagging",
+          "s3:PutObjectVersionTagging"
+        ],
+        Resource = concat(
+          [for b in local.bucket_list : "arn:aws:s3:::${local.environment_short_name}${b}"],
+          [for b in local.bucket_list : "arn:aws:s3:::${local.environment_short_name}${b}/*"]
+        ),
+        Effect = "Allow"
+      }
+    ]
+  })
+}
+
+// Define a policy that grants Lambda permission to access the secret
+resource "aws_iam_policy" "lambda_secrets_manager_policy" {
+  name_prefix = "${local.environment_short_name}lambda_secrets_manager_policy_"
+
+  // Define the permissions for accessing the secret
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "secretsmanager:GetSecretValue",
+        ],
+        Effect   = "Allow",
+        Resource = aws_secretsmanager_secret.rds_secret.arn,
+      },
+    ],
+  })
+}
+
+// Define a policy that grants Lambda permission to access the KMS key
+resource "aws_iam_policy" "lambda_kms_policy" {
+  name_prefix = "${local.environment_short_name}lambda_kms_policy_"
+
+  // Define the permissions for accessing the KMS key
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "kms:Decrypt", // Permission to decrypt the secret
+        ],
+        Effect   = "Allow",
+        Resource = aws_kms_key.default.arn // Replace with your KMS key ARN
+      },
+    ],
+  })
+}

--- a/terraform/sdc_aws_processing_lambda_function.tf
+++ b/terraform/sdc_aws_processing_lambda_function.tf
@@ -1,0 +1,226 @@
+// Resources for Processing Lambda function, RDS DB for CDFTracker, triggers and the necessary IAM permissions
+
+
+///////////////////////////////////////
+// S3 Processing Lambda Function
+///////////////////////////////////////
+
+resource "aws_lambda_function" "aws_sdc_processing_lambda_function" {
+  function_name = "${local.environment_short_name}aws_sdc_processing_lambda_function"
+  role          = aws_iam_role.processing_lambda_exec.arn
+  memory_size   = 128
+  timeout       = 900
+
+  image_uri    = "${aws_ecr_repository.processing_function_private_ecr.repository_url}:${var.image_tag}"
+  package_type = "Image"
+
+  environment {
+    variables = {
+      LAMBDA_ENVIRONMENT    = upper(local.environment_full_name)
+      RDS_SECRET_ARN        = aws_secretsmanager_secret.rds_secret.arn
+      RDS_HOST              = aws_db_instance.rds_instance.address
+      RDS_PORT              = tostring(aws_db_instance.rds_instance.port)
+      RDS_DATABASE          = aws_db_instance.rds_instance.db_name
+      SDC_AWS_SLACK_TOKEN   = var.slack_token
+      SDC_AWS_SLACK_CHANNEL = var.slack_channel
+    }
+  }
+  ephemeral_storage {
+    size = 512
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  lifecycle {
+
+    ignore_changes = [
+      environment["SDC_AWS_SLACK_TOKEN"],   # Ignore changes to this variable
+      environment["SDC_AWS_SLACK_CHANNEL"], # Ignore changes to this variable
+    ]
+  }
+
+}
+
+
+///////////////////////////////////////
+// RDS DB for CDFTracker
+///////////////////////////////////////
+
+// Generate a random password
+resource "random_password" "password" {
+  length  = 16
+  special = true
+}
+
+// KMS key used by Secrets Manager for RDS
+resource "aws_kms_key" "default" {
+  description             = "KMS key for RDS"
+  deletion_window_in_days = 30
+  is_enabled              = true
+  enable_key_rotation     = true
+
+  tags = local.standard_tags
+}
+
+// Create a secret in Secrets Manager
+resource "aws_secretsmanager_secret" "rds_secret" {
+  kms_key_id              = aws_kms_key.default.key_id
+  name                    = "${local.environment_short_name}rds-credentials"
+  description             = "RDS Credentials"
+  recovery_window_in_days = 0
+
+  tags = local.standard_tags
+}
+
+// Store the secret in Secrets Manager
+resource "aws_secretsmanager_secret_version" "secret" {
+  secret_id = aws_secretsmanager_secret.rds_secret.id
+  secret_string = jsonencode({
+    username = "cdftracker_user"
+    password = random_password.password.result
+    host     = aws_db_instance.rds_instance.address
+    port     = aws_db_instance.rds_instance.port
+    dbname   = aws_db_instance.rds_instance.db_name
+    engine   = "postgres"
+  })
+}
+
+// Create the RDS instance
+resource "aws_db_instance" "rds_instance" {
+  allocated_storage = 30
+  storage_type      = "gp2"
+  engine            = "postgres"
+  engine_version    = "14.7"
+  instance_class    = "db.t3.micro"
+  db_name           = local.is_production ? "hermes_db" : "dev_hermes_db"
+
+  username = "cdftracker_user"
+  password = random_password.password.result
+
+  parameter_group_name = "default.postgres14"
+  skip_final_snapshot  = true
+
+  multi_az                   = false
+  publicly_accessible        = true
+  storage_encrypted          = false
+  auto_minor_version_upgrade = true
+  deletion_protection        = true
+
+  tags = local.standard_tags
+}
+
+
+///////////////////////////////////////
+// Processing Lambda Triggers
+///////////////////////////////////////
+
+# Create Lambda permissions for each prefix
+resource "aws_lambda_permission" "pf_allow_instrument_buckets" {
+  for_each      = toset(local.instrument_bucket_names) # Convert to a set to ensure unique permissions
+  statement_id  = "PF${local.environment_full_name}AllowExecutionFromS3Bucket-${each.key}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.aws_sdc_processing_lambda_function.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.sdc_buckets[each.value].arn
+}
+
+# Create Lambda permissions to be invoked by topic
+resource "aws_lambda_permission" "pf_allow_sns_topic" {
+  for_each      = toset(local.instrument_bucket_names) # Convert to a set to ensure unique permissions
+  statement_id  = "PF${local.environment_full_name}AllowExecutionFromSNSTopic-${each.key}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.aws_sdc_processing_lambda_function.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.sns_topics[each.key].arn
+}
+
+// Create S3 bucket notification to trigger the Lambda function when a file is processed
+resource "aws_s3_bucket_notification" "pf_bucket_notification" {
+  count = length(local.instrument_bucket_names)
+
+  bucket = aws_s3_bucket.sdc_buckets[local.instrument_bucket_names[count.index]].id
+
+  dynamic "topic" {
+    for_each = local.data_levels
+    content {
+      topic_arn     = aws_sns_topic.sns_topics[local.instrument_bucket_names[count.index]].arn
+      events        = ["s3:ObjectCreated:Put", "s3:ObjectCreated:Copy"]
+      filter_prefix = local.data_levels[topic.key]
+    }
+  }
+
+  queue {
+    queue_arn     = aws_sqs_queue.sqs_queue[local.instrument_bucket_names[count.index]].arn
+    events        = ["s3:ObjectCreated:Put", "s3:ObjectCreated:Copy"]
+    filter_prefix = local.last_data_level
+  }
+
+  # Add a dependency on the necessary IAM permissions
+  depends_on = [aws_lambda_permission.pf_allow_instrument_buckets]
+}
+
+// Invoke Processing Lambda from SNS
+resource "aws_sns_topic_subscription" "pf_sns_topic_subscription" {
+  for_each = toset(local.instrument_bucket_names) # Convert to a set to ensure unique permissions
+
+  topic_arn = aws_sns_topic.sns_topics[each.key].arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.aws_sdc_processing_lambda_function.arn
+
+  depends_on = [aws_lambda_permission.pf_allow_sns_topic]
+}
+
+
+///////////////////////////////////////
+// Processing Lambda IAM Permissions
+///////////////////////////////////////
+
+// Create an IAM role for the Lambda function
+resource "aws_iam_role" "processing_lambda_exec" {
+  name = "${local.environment_short_name}processing_lambda_exec_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+// Attach needed policies to the role
+resource "aws_iam_role_policy_attachment" "pf_s3_bucket_policy_attachment" {
+  role       = aws_iam_role.processing_lambda_exec.name
+  policy_arn = aws_iam_policy.s3_bucket_access_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "pf_timestream_policy_attachment" {
+  role       = aws_iam_role.processing_lambda_exec.name
+  policy_arn = aws_iam_policy.timestream_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "pf_logs_policy_attachment" {
+  role       = aws_iam_role.processing_lambda_exec.name
+  policy_arn = aws_iam_policy.logs_access_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "pf_secrets_manager_policy_attachment" {
+  role       = aws_iam_role.processing_lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_secrets_manager_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "pf_lambda_kms_policy_attachment" {
+  role       = aws_iam_role.processing_lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_kms_policy.arn
+}
+
+
+
+

--- a/terraform/sdc_aws_sorting_lambda_function.tf
+++ b/terraform/sdc_aws_sorting_lambda_function.tf
@@ -1,0 +1,147 @@
+// Resources for Sorting Lambda function, triggers and the necessary IAM permissions
+
+
+///////////////////////////////////////
+// S3 Sorting Lambda Function
+///////////////////////////////////////
+
+// Get the latest version of the lambda function
+data "aws_s3_bucket" "lambda_bucket" {
+  bucket = "${local.environment_short_name}${var.sorting_lambda_bucket_name}"
+}
+
+data "aws_s3_objects" "lambda_objects" {
+  bucket = data.aws_s3_bucket.lambda_bucket.bucket
+}
+
+// Creates the Sorting Lambda function
+resource "aws_lambda_function" "sorting_lambda_function" {
+  function_name = local.is_production ? "aws_sdc_sorting_lambda_function" : "dev_aws_sdc_sorting_lambda_function"
+  handler       = "lambda_function.handler"
+  runtime       = "python3.10"
+  memory_size   = 128
+  timeout       = 600
+
+  environment {
+    variables = {
+      LAMBDA_ENVIRONMENT    = upper(local.environment_full_name)
+      SDC_AWS_SLACK_TOKEN   = var.slack_token
+      SDC_AWS_SLACK_CHANNEL = var.slack_channel
+    }
+  }
+
+  s3_bucket = "${local.environment_short_name}${var.sorting_lambda_bucket_name}"
+  s3_key    = sort(data.aws_s3_objects.lambda_objects.keys)[length(data.aws_s3_objects.lambda_objects.keys) - 1]
+
+  ephemeral_storage {
+    size = 512
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  architectures = ["x86_64"]
+  // The last object, assuming it's the latest
+
+  role = aws_iam_role.sorting_lambda_exec.arn
+
+  tags = local.standard_tags
+
+  lifecycle {
+
+    ignore_changes = [
+      environment["SDC_AWS_SLACK_TOKEN"],   // Ignore changes to this variable
+      environment["SDC_AWS_SLACK_CHANNEL"], // Ignore changes to this variable
+    ]
+  }
+}
+
+
+///////////////////////////////////////
+// S3 Sorting Lambda Function Triggers
+///////////////////////////////////////
+
+// Create a CloudWatch event rule to trigger the Lambda function every 12 hours
+resource "aws_cloudwatch_event_rule" "lambda_schedule" {
+  name                = "${aws_lambda_function.sorting_lambda_function.function_name}-rule"
+  description         = "CloudWatch event trigger for the AWS Sorting Lambda, runs every hour"
+  schedule_expression = "cron(0 0/12 * * ? *)"
+}
+
+// Attach the Lambda function as a target of the CloudWatch event rule
+resource "aws_cloudwatch_event_target" "lambda_target" {
+  rule      = aws_cloudwatch_event_rule.lambda_schedule.name
+  target_id = "${local.environment_full_name}LambdaTarget"
+  arn       = aws_lambda_function.sorting_lambda_function.arn
+}
+
+// Create S3 bucket notification to trigger the Lambda function when a file is uploaded
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.sdc_buckets["${var.incoming_bucket_name}"].id
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.sorting_lambda_function.arn
+    events              = ["s3:ObjectCreated:*"]
+  }
+
+  // Here, you may want to add a dependency on the necessary IAM permissions
+  depends_on = [aws_lambda_permission.sf_allow_cloudwatch, aws_lambda_permission.sf_allow_incoming_bucket]
+}
+
+// Allow the Lambda function to be invoked by CloudWatch
+resource "aws_lambda_permission" "sf_allow_cloudwatch" {
+  statement_id  = "SF${local.environment_full_name}AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sorting_lambda_function.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.lambda_schedule.arn
+}
+
+// Allow the Lambda function to be invoked by S3
+resource "aws_lambda_permission" "sf_allow_incoming_bucket" {
+  statement_id  = "SF${local.environment_full_name}AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sorting_lambda_function.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.sdc_buckets["${var.incoming_bucket_name}"].arn
+}
+
+
+///////////////////////////////////////
+// S3 Sorting Lambda Function IAM Permissions
+///////////////////////////////////////
+
+// Creates the needed Execution Role for the Sorting Lambda function
+resource "aws_iam_role" "sorting_lambda_exec" {
+  name = "${local.environment_short_name}sorting_lambda_exec_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+// Attach policies to the Sorting Lambda Execution Role
+resource "aws_iam_role_policy_attachment" "sf_timestream_policy_attachment" {
+  role       = aws_iam_role.sorting_lambda_exec.name
+  policy_arn = aws_iam_policy.timestream_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "sf_logs_policy_attachment" {
+  role       = aws_iam_role.sorting_lambda_exec.name
+  policy_arn = aws_iam_policy.logs_access_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "sf_s3_bucket_policy_attachment" {
+  role       = aws_iam_role.sorting_lambda_exec.name
+  policy_arn = aws_iam_policy.s3_bucket_access_policy.arn
+}
+

--- a/terraform/sdc_aws_sorting_lambda_function.tf
+++ b/terraform/sdc_aws_sorting_lambda_function.tf
@@ -5,15 +5,6 @@
 // S3 Sorting Lambda Function
 ///////////////////////////////////////
 
-// Get the latest version of the lambda function
-data "aws_s3_bucket" "lambda_bucket" {
-  bucket = "${local.environment_short_name}${var.sorting_lambda_bucket_name}"
-}
-
-data "aws_s3_objects" "lambda_objects" {
-  bucket = data.aws_s3_bucket.lambda_bucket.bucket
-}
-
 // Creates the Sorting Lambda function
 resource "aws_lambda_function" "sorting_lambda_function" {
   function_name = local.is_production ? "aws_sdc_sorting_lambda_function" : "dev_aws_sdc_sorting_lambda_function"
@@ -31,8 +22,7 @@ resource "aws_lambda_function" "sorting_lambda_function" {
   }
 
   s3_bucket = "${local.environment_short_name}${var.sorting_lambda_bucket_name}"
-  s3_key    = sort(data.aws_s3_objects.lambda_objects.keys)[length(data.aws_s3_objects.lambda_objects.keys) - 1]
-
+  s3_key    = var.s3_key
   ephemeral_storage {
     size = 512
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,76 @@
+// Variables for the Terraform deployment
+
+variable "deployment_region" {
+  type        = string
+  description = "The AWS region to deploy to"
+}
+
+variable "timestream_database_name" {
+  type        = string
+  description = "The name of the Timestream database to create"
+}
+
+variable "timestream_s3_logs_table_name" {
+  type        = string
+  description = "The name of the Timestream table to create"
+}
+
+variable "incoming_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket to create for storing incoming files"
+}
+
+variable "instrument_names" {
+  type        = list(string)
+  description = "The list of instruments"
+}
+
+variable "mission_name" {
+  type        = string
+  description = "The list of missions"
+}
+
+variable "sorting_lambda_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket to create for storing the sorting lambda"
+}
+
+variable "s3_server_access_logs_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket to create for storing access logs"
+}
+
+variable "processing_function_private_ecr_name" {
+  type        = string
+  description = "Private ECR repository for the processing function"
+}
+
+variable "docker_base_public_ecr_name" {
+  type        = string
+  description = "Public ECR repository for the docker base image"
+}
+
+variable "slack_token" {
+  type        = string
+  description = "Slack token for posting messages"
+  default     = "slack_token"
+  sensitive   = true
+}
+
+variable "slack_channel" {
+  type        = string
+  description = "Slack channel for posting messages"
+  default     = "slack_channel"
+  sensitive   = true
+}
+
+variable "image_tag" {
+  type        = string
+  description = "ECR image tag"
+  default     = "latest"
+}
+
+variable "valid_data_levels" {
+  type        = list(string)
+  description = "The list of valid data levels"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,6 +70,11 @@ variable "image_tag" {
   default     = "latest"
 }
 
+variable "s3_key" {
+  type = string
+  description = "S3 key for the sorting lambda"
+}
+
 variable "valid_data_levels" {
   type        = list(string)
   description = "The list of valid data levels"


### PR DESCRIPTION
**Description:** 

This PR contains the main Terraform refactor within the `terraform` folder. It contains all of the files needed for the deployments of both the Development and Production SDC AWS Pipelines and utilizes [Terraform workspaces ](https://developer.hashicorp.com/terraform/language/state/workspaces) to manage different environments to keep the code nice and clean.

Since our set-up was a bit simpler, creating separate folders for the infrastructure, sorting, and processing function was a bit overkill, hence keeping the simple, non-nested approach.

## Each file added explained:
- `terraform/main.tf` - This contains the configuration needed for terraform such as where to look for the state, the providers to use and the common local variables used throughout the set-up.
- `terraform/variables.tf` - This is the standard variable file which defines the variables that can be used throughout the different terraform resources. 
- `terraform/output.tf` - This is the standard output file, at the moment, we don't need to utilize it, but it should still be in the directory just in case we want to reference out resources in the future from other terraform projects.
- `terraform/config.auto.tfvars` - Think of this as the `config.yaml` file that already exists. It contains the same configurations used for the pipeline just in a way terraform can understand. They map to the variables defined in `terraform/variables.tf`.
- `terraform/sdc_aws_pipeline_infrastructure.tf` - This is equivelant [cdk_deployment/sdc_aws_pipeline_architecture.py](https://github.com/HERMES-SOC/sdc_aws_pipeline_architecture/blob/main/cdk_deployment/sdc_aws_pipeline_architecture.py) which defines the resources for the pipeline architecture.
- `terraform/sdc_aws_processing_lambda_function.tf` - This is equivalent This is equivelant [cdk_deployment/sdc_aws_processing_lambda.py](https://github.com/HERMES-SOC/sdc_aws_pipeline_architecture/blob/main/cdk_deployment/sdc_aws_processing_lambda.py) which defines the resources for the processing lambda function.
- `terraform/sdc_aws_sorting_lambda_function.tf` - This is equivalent This is equivelant [cdk_deployment/sdc_aws_sorting_lambda.py](https://github.com/HERMES-SOC/sdc_aws_pipeline_architecture/blob/main/cdk_deployment/sdc_aws_sorting_lambda.py) which defines the resources for the processing lambda function.
- `terraform/.terraform.lock.hcl` - Just a provider lock file that pins the versions of the providers defined in the `terraform/main.tf` file.

## Other Changes
- Added standard terraform cache and state files to the `.gitignore`
