### PR TITLE
Adds Artifact Lambda Function to Terraform Infra

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -27,21 +27,21 @@ phases:
       # Deployment commands
       - echo "Deploying Bootstrap Architecture..."
       - |
+        PF_ECR_REPO=sdc_aws_processing_lambda
+        SF_ECR_REPO=sdc_aws_sorting_lambda
+        AF_ECR_REPO=sdc_aws_artifacts_lambda
         if git describe --tags --exact-match > /dev/null 2>&1; then
           echo "This is a tag push event"
-          PF_ECR_REPO=sdc_aws_processing_lambda
           CDK_ENVIRONMENT=PRODUCTION
-          SF_ECR_REPO=sdc_aws_sorting_lambda
           terraform workspace select prod
         elif [ "${CDK_ENVIRONMENT}" = "PRODUCTION" ]; then
           echo "This is a production environment"
-          PF_ECR_REPO=sdc_aws_processing_lambda
-          SF_ECR_REPO=sdc_aws_sorting_lambda
           terraform workspace select prod
         else
           echo "This is a development environment"
           PF_ECR_REPO=dev-sdc_aws_processing_lambda
           SF_ECR_REPO=dev-sdc_aws_sorting_lambda
+          AF_ECR_REPO=sdc_aws_artifacts_lambda
           terraform workspace select dev
         fi
 
@@ -53,9 +53,11 @@ phases:
         SF_IMAGE_TAG=$(aws ecr describe-images --repository-name $SF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
         echo $SF_IMAGE_TAG
 
+        AF_IMAGE_TAG=$(aws ecr describe-images --repository-name $AF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
+        echo $AF_IMAGE_TAG
 
       # Run Terraform apply
-      - terraform apply -auto-approve -var "pf_image_tag=$PF_IMAGE_TAG" -var "sf_image_tag=$SF_IMAGE_TAG"
+      - terraform apply -auto-approve -var "pf_image_tag=$PF_IMAGE_TAG" -var "sf_image_tag=$SF_IMAGE_TAG" -var "af_image_tag=$AF_IMAGE_TAG"
 
       # Completion message
       - echo "Build completed on $(date)"

--- a/terraform/config.auto.tfvars
+++ b/terraform/config.auto.tfvars
@@ -29,6 +29,10 @@ incoming_bucket_name = "swsoc-incoming"
 # The name of the ECR repository that will be created to store the sorting lambda image
 sorting_function_private_ecr_name = "sdc_aws_sorting_lambda"
 
+# S3 Artifacts Lambda ECR Repository Name
+# The name of the ECR repository that will be created to store the artifacts lambda image
+artifacts_function_private_ecr_name = "sdc_aws_artifacts_lambda"
+
 # S3 Server Access Logs Bucket
 # The name of the bucket that will be created to store the s3 server access logs
 s3_server_access_logs_bucket_name = "swsoc-s3-server-access-logs"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,7 +50,7 @@ locals {
     "Purpose"     = "SWSOC Pipeline"
   }
 
-  data_levels     = slice(var.valid_data_levels, 0, length(var.valid_data_levels) - 1)
+  data_levels     = slice(var.valid_data_levels, 0, length(var.valid_data_levels))
   last_data_level = element(var.valid_data_levels, length(var.valid_data_levels) - 1)
 
   instrument_bucket_names = [for bucket in var.instrument_names : "${var.mission_name}-${bucket}"]

--- a/terraform/sdc_aws_artifacts_lambda_function.tf
+++ b/terraform/sdc_aws_artifacts_lambda_function.tf
@@ -1,0 +1,130 @@
+// Resources for Processing Artifacts Lambda function, RDS DB for CDFTracker, triggers and the necessary IAM permissions
+
+
+//////////////////////////////////////////
+// S3 Processing Artifacts Lambda Function
+//////////////////////////////////////////
+
+resource "aws_lambda_function" "aws_sdc_artifacts_lambda_function" {
+  function_name = "${local.environment_short_name}aws_sdc_artifacts_lambda_function"
+  role          = aws_iam_role.artifacts_lambda_exec.arn
+  memory_size   = 128
+  timeout       = 900
+
+  image_uri    = "${aws_ecr_repository.artifacts_function_private_ecr.repository_url}:${var.af_image_tag}"
+  package_type = "Image"
+
+  environment {
+    variables = {
+      LAMBDA_ENVIRONMENT    = upper(local.environment_full_name)
+      RDS_SECRET_ARN        = aws_secretsmanager_secret.rds_secret.arn
+      RDS_HOST              = aws_db_instance.rds_instance.address
+      RDS_PORT              = tostring(aws_db_instance.rds_instance.port)
+      RDS_DATABASE          = aws_db_instance.rds_instance.db_name
+      SDC_AWS_SLACK_TOKEN   = var.slack_token
+      SDC_AWS_SLACK_CHANNEL = var.slack_channel
+    }
+  }
+  ephemeral_storage {
+    size = 512
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  lifecycle {
+
+    ignore_changes = [
+      environment["SDC_AWS_SLACK_TOKEN"],   # Ignore changes to this variable
+      environment["SDC_AWS_SLACK_CHANNEL"], # Ignore changes to this variable
+    ]
+  }
+
+}
+
+
+///////////////////////////////////////
+// Processing Artifacts Lambda Triggers
+///////////////////////////////////////
+
+# Create Lambda permissions for each prefix
+resource "aws_lambda_permission" "af_allow_instrument_buckets" {
+  for_each      = toset(local.instrument_bucket_names) # Convert to a set to ensure unique permissions
+  statement_id  = "PF${local.environment_full_name}AllowExecutionFromS3Bucket-${each.key}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.aws_sdc_artifacts_lambda_function.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.sdc_buckets[each.value].arn
+}
+
+# Create Lambda permissions to be invoked by topic
+resource "aws_lambda_permission" "af_allow_sns_topic" {
+  for_each      = toset(local.instrument_bucket_names) # Convert to a set to ensure unique permissions
+  statement_id  = "PF${local.environment_full_name}AllowExecutionFromSNSTopic-${each.key}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.aws_sdc_artifacts_lambda_function.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.sns_topics[each.key].arn
+}
+
+// Invoke Processing Artifacts Lambda from SNS
+resource "aws_sns_topic_subscription" "af_sns_topic_subscription" {
+  for_each = toset(local.instrument_bucket_names) # Convert to a set to ensure unique permissions
+
+  topic_arn = aws_sns_topic.sns_topics[each.key].arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.aws_sdc_artifacts_lambda_function.arn
+
+  depends_on = [aws_lambda_permission.af_allow_sns_topic]
+}
+
+
+
+///////////////////////////////////////////////
+// Processing Artifacts Lambda IAM Permissions
+///////////////////////////////////////////////
+
+// Create an IAM role for the Lambda function
+resource "aws_iam_role" "artifacts_lambda_exec" {
+  name = "${local.environment_short_name}artifacts_lambda_exec_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+// Attach needed policies to the role
+resource "aws_iam_role_policy_attachment" "af_s3_bucket_policy_attachment" {
+  role       = aws_iam_role.artifacts_lambda_exec.name
+  policy_arn = aws_iam_policy.s3_bucket_access_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "af_timestream_policy_attachment" {
+  role       = aws_iam_role.artifacts_lambda_exec.name
+  policy_arn = aws_iam_policy.timestream_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "af_logs_policy_attachment" {
+  role       = aws_iam_role.artifacts_lambda_exec.name
+  policy_arn = aws_iam_policy.logs_access_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "af_secrets_manager_policy_attachment" {
+  role       = aws_iam_role.artifacts_lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_secrets_manager_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "af_lambda_kms_policy_attachment" {
+  role       = aws_iam_role.artifacts_lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_kms_policy.arn
+}

--- a/terraform/sdc_aws_pipeline_infrastructure.tf
+++ b/terraform/sdc_aws_pipeline_infrastructure.tf
@@ -203,9 +203,16 @@ resource "aws_ecr_repository" "processing_function_private_ecr" {
   tags                 = local.standard_tags
 }
 
-// Private ECR for the processing function
+// Private ECR for the sorting function
 resource "aws_ecr_repository" "sorting_function_private_ecr" {
   name                 = "${local.environment_short_name}${var.sorting_function_private_ecr_name}"
+  image_tag_mutability = "MUTABLE"
+  tags                 = local.standard_tags
+}
+
+// Private ECR for the processing artifacts function
+resource "aws_ecr_repository" "artifacts_function_private_ecr" {
+  name                 = "${local.environment_short_name}${var.artifacts_function_private_ecr_name}"
   image_tag_mutability = "MUTABLE"
   tags                 = local.standard_tags
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -45,6 +45,11 @@ variable "processing_function_private_ecr_name" {
   description = "Private ECR repository for the processing function"
 }
 
+variable "artifacts_function_private_ecr_name" {
+  type        = string
+  description = "Private ECR repository for the artifacts function"
+}
+
 variable "docker_base_public_ecr_name" {
   type        = string
   description = "Public ECR repository for the docker base image"
@@ -73,6 +78,12 @@ variable "pf_image_tag" {
 variable "sf_image_tag" {
   type        = string
   description = "Sorting Function ECR image tag"
+  default     = "latest"
+}
+
+variable "af_image_tag" {
+  type        = string
+  description = "Artifact Function ECR image tag"
   default     = "latest"
 }
 


### PR DESCRIPTION
Description:

This modifies the infrastructure and goes along with the processing lambda refactor (https://github.com/HERMES-SOC/sdc_aws_processing_lambda/pull/20) to support the new calibration workflow, which will be added here (and to other instrument packages after): https://github.com/HERMES-SOC/hermes_eea/pull/30

All of the artifact generation logic has been taken out of the processing lambda, leaving it to only handle calibration and moved to a separate 'artifacts' lambda that is called by the same SNS topic which also calls the processing lambda. So the event gets delegated to both functions in parallel, allowing to keep the processing lambda lean.

The artifact lambda handles, inputting the files into the RDS database with CDFTracker, Logging to timestream and slack notifications. It can support other artifacts we'd like to generate in the future. Repo can be found here: https://github.com/HERMES-SOC/sdc_aws_artifacts_lambda

